### PR TITLE
fix: 自定义颜色划分问题

### DIFF
--- a/examples/builder/package.json
+++ b/examples/builder/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.0.1",
     "@antv/l7": "^2.17.2",
-    "@antv/larkmap": "^1.4.1",
+    "@antv/larkmap": "^1.4.9",
     "@antv/li-analysis-assets": "link:../../packages/li-analysis-assets",
     "@antv/li-core-assets": "link:../../packages/li-core-assets",
     "@antv/li-editor": "link:../../packages/li-editor",

--- a/examples/li-template-assets/package.json
+++ b/examples/li-template-assets/package.json
@@ -45,7 +45,7 @@
     "@antv/li-editor": "^1.0.0",
     "@ant-design/icons": "^5.0.1",
     "@antv/l7": "^2.17.2",
-    "@antv/larkmap": "^1.4.1",
+    "@antv/larkmap": "^1.4.9",
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",
     "@types/lodash-es": "^4.17.6",
@@ -69,7 +69,7 @@
   "peerDependencies": {
     "@ant-design/icons": "^5.0.1",
     "@antv/l7": "^2.17.2",
-    "@antv/larkmap": "^1.4.1",
+    "@antv/larkmap": "^1.4.9",
     "antd": "^5.4.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/packages/li-analysis-assets/package.json
+++ b/packages/li-analysis-assets/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@ant-design/icons": "^5.0.1",
     "@antv/l7": "^2.17.2",
-    "@antv/larkmap": "^1.4.1",
+    "@antv/larkmap": "^1.4.9",
     "@antv/li-core-assets": "^1.0.17",
     "@antv/li-editor": "^1.2.2",
     "@types/react": "^18.0.0",
@@ -69,7 +69,7 @@
   "peerDependencies": {
     "@ant-design/icons": "^5.0.1",
     "@antv/l7": "^2.17.2",
-    "@antv/larkmap": "^1.4.1",
+    "@antv/larkmap": "^1.4.9",
     "antd": "^5.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/packages/li-analysis-assets/src/layers/ChinaAdminLayer/register-form/index.ts
+++ b/packages/li-analysis-assets/src/layers/ChinaAdminLayer/register-form/index.ts
@@ -61,11 +61,6 @@ const fromValues = (values: Record<string, any>): LayerRegisterFormResultType<Ch
   ]);
   const showNationalStyle = pick(values, ['showNationalBorders']);
 
-  // TODO: 没有值时置灰
-  if (typeof visConfig.fillColor === 'object' && visConfig.fillColor.scale) {
-    visConfig.fillColor.scale.unknown = '#c0c0c0';
-  }
-
   return {
     sourceConfig,
     visConfig: {

--- a/packages/li-analysis-assets/src/widgets/LegendWidget/helper.ts
+++ b/packages/li-analysis-assets/src/widgets/LegendWidget/helper.ts
@@ -122,6 +122,15 @@ export const parserLegendData = (layer: Layer) => {
     const catData = labels
       .map((label, index) => ({ label, color: colors[index] }))
       .sort((a, b) => a.label.localeCompare(b.label, 'zh-CN'));
+    // string 文本自定义的情况，需要展示出其他分类
+    const unknownItem = { label: '其他', color: layer.options.fillColor.scale.unknown };
+    const _labels = unknownItem.color
+      ? [...catData.map((item) => item.label), unknownItem.label]
+      : catData.map((item) => item.label);
+    const _colors = unknownItem.color
+      ? [...catData.map((item) => item.color).filter(Boolean), unknownItem.color]
+      : catData.map((item) => item.color).filter(Boolean);
+
     const data: LegendCategoriesData = {
       type: 'LegendCategories',
       field: field,
@@ -130,8 +139,8 @@ export const parserLegendData = (layer: Layer) => {
       visible: true,
       data: {
         geometryType: 'square',
-        labels: catData.map((item) => item.label),
-        colors: catData.map((item) => item.color).filter(Boolean),
+        labels: _labels,
+        colors: _colors,
       },
     };
 

--- a/packages/li-analysis-assets/src/widgets/LegendWidget/helper.ts
+++ b/packages/li-analysis-assets/src/widgets/LegendWidget/helper.ts
@@ -34,28 +34,42 @@ export const parserLegendData = (layer: Layer) => {
   }
 
   // 如果是图标图层
-  if (
-    layer.type === 'iconImageLayer' &&
-    layer.options?.icon?.field &&
-    layer.options?.iconAtlas &&
-    layer.options?.icon?.value
-  ) {
-    const iconAtlas = layer.options.iconAtlas;
+  if (layer.type === 'iconImageLayer') {
+    if (layer.options?.icon?.field && layer.options?.iconAtlas && layer.options?.icon?.value) {
+      const iconAtlas = layer.options.iconAtlas;
 
-    const icons = layer.options.icon.value.map((item: string) => iconAtlas[item]);
+      const icons = layer.options.icon.value.map((item: string) => iconAtlas[item]);
 
-    const data: LegendIconData = {
-      type: 'LegendIcon',
-      name,
-      layer,
-      visible: true,
-      data: {
-        labels: layer.options.icon.scale.domain,
-        icons,
-      },
-    };
+      const data: LegendIconData = {
+        type: 'LegendIcon',
+        name,
+        layer,
+        visible: true,
+        data: {
+          labels: layer.options.icon.scale.domain,
+          icons,
+        },
+      };
 
-    return data;
+      return data;
+    } else {
+      const iconAtlas = layer.options.iconAtlas;
+
+      const icons = [iconAtlas[layer.options.icon]];
+
+      const data: LegendIconData = {
+        type: 'LegendIcon',
+        name,
+        layer,
+        visible: true,
+        data: {
+          labels: [''],
+          icons,
+        },
+      };
+
+      return data;
+    }
   }
 
   let legendData: ILegend;

--- a/packages/li-core-assets/package.json
+++ b/packages/li-core-assets/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@ant-design/icons": "^5.0.1",
     "@antv/l7": "^2.17.2",
-    "@antv/larkmap": "^1.4.1",
+    "@antv/larkmap": "^1.4.9",
     "@antv/li-editor": "^1.2.2",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "@ant-design/icons": "^5.0.1",
     "@antv/l7": "^2.17.2",
-    "@antv/larkmap": "^1.4.1",
+    "@antv/larkmap": "^1.4.9",
     "antd": "^5.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/packages/li-core-assets/src/layers/BubbleLayer/register-form/index.ts
+++ b/packages/li-core-assets/src/layers/BubbleLayer/register-form/index.ts
@@ -33,11 +33,6 @@ const fromValues = (values: Record<string, any>): LayerRegisterFormResultType<Bu
   };
   const visConfig = bubbleLayerStyleFlatToConfig(values);
 
-  // TODO: 没有值时置灰
-  if (typeof visConfig.fillColor === 'object' && visConfig.fillColor.scale) {
-    visConfig.fillColor.scale.unknown = '#c0c0c0';
-  }
-
   return {
     sourceConfig,
     visConfig,

--- a/packages/li-core-assets/src/layers/ChoroplethLayer/register-form/index.ts
+++ b/packages/li-core-assets/src/layers/ChoroplethLayer/register-form/index.ts
@@ -27,11 +27,6 @@ const fromValues = (values: Record<string, any>): LayerRegisterFormResultType<Ch
   };
   const visConfig = choroplethLayerStyleFlatToConfig(values);
 
-  // TODO: 没有值时置灰
-  if (typeof visConfig.fillColor === 'object' && visConfig.fillColor.scale) {
-    visConfig.fillColor.scale.unknown = '#c0c0c0';
-  }
-
   return {
     sourceConfig,
     visConfig,

--- a/packages/li-core-assets/src/layers/H3HexagonLayer/register-form/index.ts
+++ b/packages/li-core-assets/src/layers/H3HexagonLayer/register-form/index.ts
@@ -18,6 +18,7 @@ const toValues = (config: LayerRegisterFormResultType<ChoroplethLayerStyleAttrib
           type: fillColor?.scale?.type,
           domain: fillColor?.scale?.domain,
           range: fillColor?.value,
+          unknown: fillColor?.scale?.unknown,
           isCustom,
         }
       : undefined;
@@ -59,6 +60,7 @@ const fromValues = (style: Record<string, any>): LayerRegisterFormResultType<Cho
           ? {
               type: style.fillColorScale.type,
               domain: style.fillColorScale.domain,
+              unknown: style.fillColorScale.unknown,
             }
           : {
               type: style.fillColorScale.type,

--- a/packages/li-editor/package.json
+++ b/packages/li-editor/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@ant-design/icons": "^5.0.1",
     "@antv/l7": "^2.17.2",
-    "@antv/larkmap": "^1.4.1",
+    "@antv/larkmap": "^1.4.9",
     "@types/geojson": "^7946.0.10",
     "@types/lodash-es": "^4.17.6",
     "@types/papaparse": "^5.3.3",
@@ -78,7 +78,7 @@
   "peerDependencies": {
     "@ant-design/icons": "^5.0.1",
     "@antv/l7": "^2.17.2",
-    "@antv/larkmap": "^1.4.1",
+    "@antv/larkmap": "^1.4.9",
     "antd": "^5.5.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/packages/li-p2/package.json
+++ b/packages/li-p2/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@ant-design/icons": "^5.0.1",
     "@antv/l7": "^2.17.2",
-    "@antv/larkmap": "^1.4.1",
+    "@antv/larkmap": "^1.4.9",
     "@types/lodash-es": "^4.17.6",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",

--- a/packages/li-p2/src/LayerAttribute/BubbleLayerStyle/helper.ts
+++ b/packages/li-p2/src/LayerAttribute/BubbleLayerStyle/helper.ts
@@ -13,6 +13,7 @@ export const bubbleLayerStyleFlatToConfig = (style: Record<string, any>) => {
           ? {
               type: style.fillColorScale.type,
               domain: style.fillColorScale.domain,
+              unknown: style.fillColorScale.unknown,
             }
           : {
               type: style.fillColorScale.type,
@@ -84,6 +85,7 @@ export const bubbleLayerStyleConfigToFlat = (styleConfig: BubbleLayerStyleAttrib
           type: fillColor?.scale?.type,
           domain: fillColor?.scale?.domain,
           range: fillColor?.value,
+          unknown: fillColor?.scale?.unknown,
           isCustom,
         }
       : undefined;

--- a/packages/li-p2/src/LayerAttribute/ChoroplethLayerStyle/helper.ts
+++ b/packages/li-p2/src/LayerAttribute/ChoroplethLayerStyle/helper.ts
@@ -13,6 +13,7 @@ export const choroplethLayerStyleFlatToConfig = (style: Record<string, any>) => 
           ? {
               type: style.fillColorScale.type,
               domain: style.fillColorScale.domain,
+              unknown: style.fillColorScale.unknown,
             }
           : {
               type: style.fillColorScale.type,
@@ -72,6 +73,7 @@ export const choroplethLayerStyleConfigToFlat = (styleConfig: ChoroplethLayerSty
           type: fillColor?.scale?.type,
           domain: fillColor?.scale?.domain,
           range: fillColor?.value,
+          unknown: fillColor?.scale?.unknown,
           isCustom,
         }
       : undefined;

--- a/packages/li-p2/src/LayerAttribute/LineLayerStyle/helper.ts
+++ b/packages/li-p2/src/LayerAttribute/LineLayerStyle/helper.ts
@@ -13,6 +13,7 @@ export const lineLayerStyleFlatToConfig = (style: Record<string, any>) => {
           ? {
               type: style.fillColorScale.type,
               domain: style.fillColorScale.domain,
+              unknown: style.fillColorScale.unknown,
             }
           : {
               type: style.fillColorScale.type,
@@ -66,6 +67,7 @@ export const lineLayerStyleConfigToFlat = (styleConfig: LineLayerStyleAttributeV
           type: color?.scale?.type,
           domain: color?.scale?.domain,
           range: color?.value,
+          unknown: color?.scale?.unknown,
           isCustom,
         }
       : undefined;

--- a/packages/li-p2/src/LayerAttribute/components/ResterScaleSelector/CustomMappingColors/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ResterScaleSelector/CustomMappingColors/index.tsx
@@ -50,6 +50,7 @@ const CustomMappingColor = (props: CustomMappingColorProps) => {
         {type === 'cat' && <CustomCat value={customRanges} onChange={onCustomRangesChange} />}
         {type === 'custom' && (
           <CustomNumber
+            domain={domain as [number, number]}
             value={customRanges}
             onChange={(list) => onCustomRangesChange(list as CustomMappingColorItem[])}
           />

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomNumber/CustomItem/InputNumber/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomNumber/CustomItem/InputNumber/index.tsx
@@ -89,7 +89,7 @@ const NumberItem = ({ size = 'middle', value, min = -Infinity, max = Infinity, p
               controls={false}
               size={size}
               min={min}
-              max={max}
+              max={itemVal?.[1]}
               value={itemVal?.[0]}
               className={`${prefixCls}__input`}
               onChange={(e) => onFirstInputChange(e as number)}
@@ -100,7 +100,7 @@ const NumberItem = ({ size = 'middle', value, min = -Infinity, max = Infinity, p
             <InputNumber
               controls={false}
               size={size}
-              min={min}
+              min={itemVal?.[0]}
               max={max}
               value={itemVal?.[1]}
               className={`${prefixCls}__input`}

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomNumber/CustomItem/style.ts
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomNumber/CustomItem/style.ts
@@ -1,7 +1,7 @@
 import { genStyleHook } from '@formily/antd-v5/esm/__builtins__';
 
 export default genStyleHook('scale-selector__custom-content__custom-number__input', (token) => {
-  const { componentCls, antCls, colorTextDescription } = token;
+  const { componentCls, antCls, colorTextDescription, colorBorder, lineType } = token;
 
   return {
     [componentCls]: {
@@ -20,6 +20,8 @@ export default genStyleHook('scale-selector__custom-content__custom-number__inpu
         '&__color': {
           width: '18px',
           height: '18px',
+          border: `1px ${colorBorder} ${lineType}`,
+          borderRadius: '4px',
         },
 
         '&__content': {

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomNumber/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomNumber/index.tsx
@@ -9,39 +9,53 @@ import useStyle from './style';
 
 type CustomNumberProps = {
   value: CustomMappingColorItem[];
+  domain: [number, number];
   onChange: (value: CustomMappingColorItem[]) => void;
   className?: string;
 };
 
 const CustomNumber = (props: CustomNumberProps) => {
-  const { value: defaultValue = [], onChange, className } = props;
+  const { value: defaultValue = [], domain, onChange, className } = props;
   const prefixCls = usePrefixCls('formily-color-range-selector__custom-number');
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
   const addPaletteRangeItem = () => {
-    const _item = defaultValue[defaultValue.length - 2];
-    const min = Number(_item.value[0]);
-    const _interval = Number(((Number(_item.value[1]) - Number(_item.value[0])) / 2).toFixed(2));
-    const _range = [min, Number((_interval + min).toFixed(2)), Number(_item.value[1])];
+    // 初始为0
+    if (defaultValue.length === 0) {
+      const _medianValue = Number(((Number(domain[1]) - Number(domain[0])) / 2).toFixed(2));
+      const addList: CustomMappingColorItem[] = [
+        {
+          id: uniqueId(),
+          value: [-Infinity, _medianValue],
+          color: '#5B8FF9',
+        },
+        {
+          id: uniqueId(),
+          value: [_medianValue, Infinity],
+          color: '#5B8FF9',
+        },
+      ];
+      return onChange(addList);
+    }
+
+    const _domain: [number, number] = [Number(defaultValue[defaultValue.length - 1].value[0]), domain[1]];
+    const _medianValue: number = Number(((Number(_domain[1]) - Number(_domain[0])) / 2).toFixed(2));
+    const ranges = [Number((_medianValue + _domain[0]).toFixed(2)), Number(_domain[1])];
 
     const addList: CustomMappingColorItem[] = [
       {
-        id: _item.id,
-        value: [_range[0], _range[1]],
-        color: _item.color ?? '#5B8FF9',
-      },
-      {
         id: defaultValue[defaultValue.length - 1].id,
-        value: [_range[1], _range[2]],
+        value: [_domain[0], ranges[1]],
         color: defaultValue[defaultValue.length - 1].color ?? '#5B8FF9',
       },
       {
         id: uniqueId(),
-        value: [_range[2], Infinity],
+        value: [ranges[1], Infinity],
         color: defaultValue[defaultValue.length - 1].color ?? '#5B8FF9',
       },
     ];
-    const list = [...defaultValue.slice(0, -2), ...addList];
+
+    const list = [...defaultValue.slice(0, -1), ...addList];
     onChange(list);
   };
 
@@ -115,8 +129,9 @@ const CustomNumber = (props: CustomNumberProps) => {
     <div className={classnames(`${prefixCls}`, hashId, className)}>
       {defaultValue.map((customItem: CustomMappingColorItem, index: number) => {
         const position = index === 0 ? 'first' : index === defaultValue.length - 1 ? 'last' : null;
+        console.log(position, 'position');
         const _min = position === 'first' ? -Infinity : (defaultValue[index - 1].value[1] as number);
-        const _max = position === 'last' ? Infinity : defaultValue[index + 1].value[1];
+        const _max = position === 'last' ? Infinity : defaultValue[index + 1]?.value?.[1];
 
         return (
           <CustomItem
@@ -126,7 +141,7 @@ const CustomNumber = (props: CustomNumberProps) => {
             min={_min as number}
             max={_max as number}
             position={position}
-            delDisable={defaultValue.length <= 3}
+            delDisable={defaultValue.length <= 2}
             onDelete={() => deletePaletteRangeItem(index, position)}
             onChange={(value: (string | number)[], color: string) => onChangePaletteRangeItem(value, color, index)}
           />

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomNumber/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomNumber/index.tsx
@@ -28,13 +28,12 @@ const CustomNumber = (props: CustomNumberProps) => {
         {
           id: uniqueId(),
           value: [-Infinity, _medianValue],
-          // TODO 换一个颜色
-          color: '#5B8FF9',
+          color: '#bdd7e7',
         },
         {
           id: uniqueId(),
           value: [_medianValue, Infinity],
-          color: '#5B8FF9',
+          color: '#6baed6',
         },
       ];
 

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomNumber/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomNumber/index.tsx
@@ -38,9 +38,10 @@ const CustomNumber = (props: CustomNumberProps) => {
       return onChange(addList);
     }
 
-    const _domain: [number, number] = [Number(defaultValue[defaultValue.length - 1].value[0]), domain[1]];
+    const _domain: [number, number] =
+      defaultValue.length === 1 ? domain : [Number(defaultValue[defaultValue.length - 1].value[0]), domain[1]];
     const _medianValue: number = Number(((Number(_domain[1]) - Number(_domain[0])) / 2).toFixed(2));
-    const ranges = [Number((_medianValue + _domain[0]).toFixed(2)), Number(_domain[1])];
+    const ranges = [Number(_domain[0]), Number((_medianValue + _domain[0]).toFixed(2))];
 
     const addList: CustomMappingColorItem[] = [
       {
@@ -56,6 +57,7 @@ const CustomNumber = (props: CustomNumberProps) => {
     ];
 
     const list = [...defaultValue.slice(0, -1), ...addList];
+
     onChange(list);
   };
 
@@ -129,8 +131,7 @@ const CustomNumber = (props: CustomNumberProps) => {
     <div className={classnames(`${prefixCls}`, hashId, className)}>
       {defaultValue.map((customItem: CustomMappingColorItem, index: number) => {
         const position = index === 0 ? 'first' : index === defaultValue.length - 1 ? 'last' : null;
-        console.log(position, 'position');
-        const _min = position === 'first' ? -Infinity : (defaultValue[index - 1].value[1] as number);
+        const _min = position === 'first' ? -Infinity : (defaultValue[index - 1].value[0] as number);
         const _max = position === 'last' ? Infinity : defaultValue[index + 1]?.value?.[1];
 
         return (

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomNumber/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomNumber/index.tsx
@@ -20,13 +20,15 @@ const CustomNumber = (props: CustomNumberProps) => {
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
   const addPaletteRangeItem = () => {
-    // 初始为0
+    // 初始为空数组
     if (defaultValue.length === 0) {
+      // 取最大最小值的平均数
       const _medianValue = Number(((Number(domain[1]) - Number(domain[0])) / 2).toFixed(2));
       const addList: CustomMappingColorItem[] = [
         {
           id: uniqueId(),
           value: [-Infinity, _medianValue],
+          // TODO 换一个颜色
           color: '#5B8FF9',
         },
         {
@@ -35,11 +37,14 @@ const CustomNumber = (props: CustomNumberProps) => {
           color: '#5B8FF9',
         },
       ];
-      return onChange(addList);
+
+      onChange(addList);
+      return;
     }
 
     const _domain: [number, number] =
       defaultValue.length === 1 ? domain : [Number(defaultValue[defaultValue.length - 1].value[0]), domain[1]];
+
     const _medianValue: number = Number(((Number(_domain[1]) - Number(_domain[0])) / 2).toFixed(2));
     const ranges = [Number(_domain[0]), Number((_medianValue + _domain[0]).toFixed(2))];
 

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomString/UnknownItem/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomString/UnknownItem/index.tsx
@@ -1,0 +1,46 @@
+import { DeleteOutlined } from '@ant-design/icons';
+import { usePrefixCls } from '@formily/antd-v5/esm/__builtins__';
+import { ColorPicker, Select } from 'antd';
+import type { Color } from 'antd/es/color-picker';
+import classnames from 'classnames';
+import React, { useMemo } from 'react';
+import useStyle from './style';
+
+type UnknownItemProps = {
+  color: string;
+  onChange: (color: string) => void;
+};
+
+const UnknownItem = ({ color: defaultColor, onChange }: UnknownItemProps) => {
+  const prefixCls = usePrefixCls('formily-scale-selector__custom-string-unknown');
+  const [wrapSSR, hashId] = useStyle(prefixCls);
+
+  const colorChange = (color: Color) => {
+    onChange?.(color.toHexString());
+  };
+
+  return wrapSSR(
+    <div className={classnames(`${prefixCls}`, hashId)}>
+      <div className={`${prefixCls}__infor`}>
+        <div
+          onMouseDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
+          <ColorPicker value={defaultColor ? defaultColor : '#5B8FF9'} onChange={colorChange}>
+            <div className={`${prefixCls}__infor__color`} style={{ background: defaultColor }} />
+          </ColorPicker>
+        </div>
+
+        <div className={`${prefixCls}__infor__content`}>
+          <Select size="small" style={{ width: '100%' }} disabled placeholder="其他" />
+        </div>
+
+        <div className={`${prefixCls}__infor__delete-icon`} />
+      </div>
+    </div>,
+  );
+};
+
+export default UnknownItem;

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomString/UnknownItem/style.ts
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomString/UnknownItem/style.ts
@@ -1,7 +1,7 @@
 import { genStyleHook } from '@formily/antd-v5/esm/__builtins__';
 
-export default genStyleHook('scale-selector__custom-string', (token) => {
-  const { componentCls, antCls, colorInfoTextHover } = token;
+export default genStyleHook('scale-selector__custom-string-unknown', (token) => {
+  const { componentCls, antCls, colorBorder, lineType, borderRadius } = token;
 
   return {
     [componentCls]: {
@@ -20,7 +20,8 @@ export default genStyleHook('scale-selector__custom-string', (token) => {
         '&__color': {
           width: '18px',
           height: '18px',
-          borderRadius: '4px',
+          border: `1px ${colorBorder} ${lineType}`,
+          borderRadius: `${borderRadius}px`,
         },
 
         '&__content': {
@@ -32,10 +33,6 @@ export default genStyleHook('scale-selector__custom-string', (token) => {
 
         '&__delete-icon': {
           width: '14px',
-        },
-
-        '&__delete-icon:hover': {
-          color: colorInfoTextHover,
         },
       },
     },

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomString/UnknownItem/style.ts
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomString/UnknownItem/style.ts
@@ -1,7 +1,7 @@
 import { genStyleHook } from '@formily/antd-v5/esm/__builtins__';
 
 export default genStyleHook('scale-selector__custom-string-unknown', (token) => {
-  const { componentCls, antCls, colorBorder, lineType, borderRadius } = token;
+  const { componentCls, antCls, colorBorder, lineType } = token;
 
   return {
     [componentCls]: {
@@ -21,7 +21,7 @@ export default genStyleHook('scale-selector__custom-string-unknown', (token) => 
           width: '18px',
           height: '18px',
           border: `1px ${colorBorder} ${lineType}`,
-          borderRadius: `${borderRadius}px`,
+          borderRadius: '4px',
         },
 
         '&__content': {

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomString/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomString/index.tsx
@@ -13,12 +13,12 @@ type CustomStringProps = {
   unknown: string;
   value: CustomMappingColorItem[];
   onChange: (value: CustomMappingColorItem[]) => void;
-  onUnknownColorChange: (color: string) => void;
+  onUnknownChange: (color: string) => void;
   className?: string;
 };
 
 const CustomString = (props: CustomStringProps) => {
-  const { value: defaultValue = [], unknown = '#f000', domain, onChange, onUnknownColorChange, className } = props;
+  const { value: defaultValue = [], unknown = '#f000', domain, onChange, onUnknownChange, className } = props;
   const prefixCls = usePrefixCls('formily-color-range-selector__custom-string');
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
@@ -83,7 +83,7 @@ const CustomString = (props: CustomStringProps) => {
         );
       })}
 
-      <UnknownItem color={unknown} onChange={onUnknownColorChange} />
+      <UnknownItem color={unknown} onChange={onUnknownChange} />
 
       <div onClick={addPaletteRangeItem} className={`${prefixCls}__add-range-item`}>
         <PlusOutlined /> 添加

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomString/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/CustomString/index.tsx
@@ -6,16 +6,19 @@ import React, { useMemo } from 'react';
 import type { CustomMappingColorItem } from '../../type';
 import CustomItem from './CustomItem';
 import useStyle from './style';
+import UnknownItem from './UnknownItem';
 
 type CustomStringProps = {
-  domain: string[] | [number, number];
+  domain: string[];
+  unknown: string;
   value: CustomMappingColorItem[];
   onChange: (value: CustomMappingColorItem[]) => void;
+  onUnknownColorChange: (color: string) => void;
   className?: string;
 };
 
 const CustomString = (props: CustomStringProps) => {
-  const { value: defaultValue = [], domain, onChange, className } = props;
+  const { value: defaultValue = [], unknown = '#f000', domain, onChange, onUnknownColorChange, className } = props;
   const prefixCls = usePrefixCls('formily-color-range-selector__custom-string');
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
@@ -79,6 +82,8 @@ const CustomString = (props: CustomStringProps) => {
           />
         );
       })}
+
+      <UnknownItem color={unknown} onChange={onUnknownColorChange} />
 
       <div onClick={addPaletteRangeItem} className={`${prefixCls}__add-range-item`}>
         <PlusOutlined /> 添加

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/index.tsx
@@ -47,7 +47,9 @@ const CustomMappingColor = (props: CustomMappingColorProps) => {
   return wrapSSR(
     <div className={classnames(`${prefixCls}`, hashId, className)}>
       <div className={classnames(`${prefixCls}_custom-content`, hashId, className)}>
-        {dataType === 'number' && <CustomNumber value={customRanges} onChange={onCustomRangesChange} />}
+        {dataType === 'number' && (
+          <CustomNumber value={customRanges} domain={domain as [number, number]} onChange={onCustomRangesChange} />
+        )}
 
         {dataType === 'string' && <CustomString domain={domain} value={customRanges} onChange={onCustomRangesChange} />}
       </div>

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/index.tsx
@@ -17,11 +17,11 @@ type CustomMappingColorProps = {
 };
 
 const CustomMappingColor = (props: CustomMappingColorProps) => {
-  const { dataType = 'string', domain, value, unknown = '#f000', onChange, className } = props;
+  const { dataType = 'string', domain, value, onChange, className } = props;
   const prefixCls = usePrefixCls('formily-color-range-selector__custom-range');
   const [wrapSSR, hashId] = useStyle(prefixCls);
   const [customRanges, setCustomRanges] = useState<CustomMappingColorItem[]>([]);
-  const [unknownColor, setUnknownColor] = useState<string>(unknown);
+  const [unknown, setUnknown] = useState<string>(props.unknown ?? '#f000');
 
   useEffect(() => {
     if (value?.list?.length) {
@@ -43,7 +43,7 @@ const CustomMappingColor = (props: CustomMappingColorProps) => {
     const list = customRanges.map((item) => {
       return { value: item.value, color: item.color };
     });
-    onChange({ type: dataType, list, unknown: unknownColor });
+    onChange({ type: dataType, list, unknown: unknown });
   };
 
   return wrapSSR(
@@ -58,9 +58,9 @@ const CustomMappingColor = (props: CustomMappingColorProps) => {
             domain={domain as string[]}
             value={customRanges}
             onChange={onCustomRangesChange}
-            unknown={unknownColor}
-            onUnknownColorChange={(color: string) => {
-              setUnknownColor(color);
+            unknown={unknown}
+            onUnknownChange={(color: string) => {
+              setUnknown(color);
             }}
           />
         )}

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/CustomMappingColors/index.tsx
@@ -11,15 +11,17 @@ type CustomMappingColorProps = {
   dataType: 'string' | 'number';
   domain: string[] | [number, number];
   value?: CustomMappingData;
+  unknown?: string;
   onChange: (value: CustomMappingData) => void;
   className?: string;
 };
 
 const CustomMappingColor = (props: CustomMappingColorProps) => {
-  const { dataType = 'string', domain, value, onChange, className } = props;
+  const { dataType = 'string', domain, value, unknown = '#f000', onChange, className } = props;
   const prefixCls = usePrefixCls('formily-color-range-selector__custom-range');
   const [wrapSSR, hashId] = useStyle(prefixCls);
   const [customRanges, setCustomRanges] = useState<CustomMappingColorItem[]>([]);
+  const [unknownColor, setUnknownColor] = useState<string>(unknown);
 
   useEffect(() => {
     if (value?.list?.length) {
@@ -41,7 +43,7 @@ const CustomMappingColor = (props: CustomMappingColorProps) => {
     const list = customRanges.map((item) => {
       return { value: item.value, color: item.color };
     });
-    onChange({ type: dataType, list });
+    onChange({ type: dataType, list, unknown: unknownColor });
   };
 
   return wrapSSR(
@@ -51,7 +53,17 @@ const CustomMappingColor = (props: CustomMappingColorProps) => {
           <CustomNumber value={customRanges} domain={domain as [number, number]} onChange={onCustomRangesChange} />
         )}
 
-        {dataType === 'string' && <CustomString domain={domain} value={customRanges} onChange={onCustomRangesChange} />}
+        {dataType === 'string' && (
+          <CustomString
+            domain={domain as string[]}
+            value={customRanges}
+            onChange={onCustomRangesChange}
+            unknown={unknownColor}
+            onUnknownColorChange={(color: string) => {
+              setUnknownColor(color);
+            }}
+          />
+        )}
       </div>
 
       <div className={`${prefixCls}__btn`}>

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/constants.ts
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/constants.ts
@@ -33,3 +33,8 @@ export const DEHAULT_OPTIONS: {
     type: 'number',
   },
 ];
+
+export const DEHAULT_COLORS = {
+  string: ['#bdd7e7', '#6baed6', '#3182bd'],
+  number: ['#ffeda0', '#feb24c', '#f03b20'],
+};

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/helper.ts
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/helper.ts
@@ -41,6 +41,7 @@ export const getDefaultValue = (
       type: 'threshold',
       domain: _domain,
       range,
+      unknown: '#f000',
     };
 
     return defaultValue;
@@ -60,6 +61,7 @@ export const getDefaultValue = (
       type: 'cat',
       domain,
       range: colors,
+      unknown: '#f000',
     };
 
     return defaultValue;
@@ -84,6 +86,8 @@ export const getScaleByCustomMappingData = (val: CustomMappingData) => {
 
     return scaleValue;
   }
+
+  console.log(unknown, 'unknown');
 
   const { domain, range } = getScaleDataByMappingColors(list);
   const scaleValue: SelectorValue = {

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/helper.ts
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/helper.ts
@@ -87,8 +87,6 @@ export const getScaleByCustomMappingData = (val: CustomMappingData) => {
     return scaleValue;
   }
 
-  console.log(unknown, 'unknown');
-
   const { domain, range } = getScaleDataByMappingColors(list);
   const scaleValue: SelectorValue = {
     isCustom: true,

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/helper.ts
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/helper.ts
@@ -68,7 +68,7 @@ export const getDefaultValue = (
 
 // 通过自定义颜色映射转换为 Scale 的数据格式
 export const getScaleByCustomMappingData = (val: CustomMappingData) => {
-  const { type, list } = val;
+  const { type, list, unknown = '#f000' } = val;
 
   if (type === 'number') {
     const range = list.map((item) => item.color);
@@ -90,6 +90,7 @@ export const getScaleByCustomMappingData = (val: CustomMappingData) => {
     type: 'cat',
     domain,
     range,
+    unknown,
   };
 
   return scaleValue;

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/helper.ts
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/helper.ts
@@ -79,6 +79,7 @@ export const getScaleByCustomMappingData = (val: CustomMappingData) => {
       type: 'threshold',
       domain: _val,
       range,
+      unknown,
     };
 
     return scaleValue;

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/index.tsx
@@ -1,10 +1,9 @@
 import { usePrefixCls } from '@formily/antd-v5/esm/__builtins__';
 import { connect } from '@formily/react';
-import { useUpdateEffect } from 'ahooks';
 import { Divider, Select } from 'antd';
 import cls from 'classnames';
-import React, { useEffect, useMemo, useState } from 'react';
-import { DEHAULT_OPTIONS, DEHAULT_COLORS } from './constants';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { DEHAULT_COLORS, DEHAULT_OPTIONS } from './constants';
 import CustomMappingColor from './CustomMappingColors';
 import { getCustomMappingData, getDefaultValue, getScaleByCustomMappingData } from './helper';
 import useStyle from './style';
@@ -36,15 +35,16 @@ type ScaleSelectorProp = {
 const Internal = (props: ScaleSelectorProp) => {
   const prefixCls = usePrefixCls('formily-scale-selector');
   const { dataType, value, domain = [], onChange } = props;
+  const lastDataStateRef = useRef<{ dataType: 'string' | 'number'; domain: [number, number] | string[] } | null>(null);
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
   const defaultColors = useMemo(() => {
     if (props.defaultColors) {
       return props.defaultColors;
+    } else {
+      return DEHAULT_COLORS[dataType];
     }
-
-    return DEHAULT_COLORS[dataType];
-  }, [dataType]);
+  }, [props.defaultColors]);
 
   const customMappingData = useMemo(() => {
     if (value) {
@@ -82,40 +82,50 @@ const Internal = (props: ScaleSelectorProp) => {
     }
   };
 
-  // dataType 变更，引起可选类型变更，当 scale 为非自定义时自动填充当前类型
   useEffect(() => {
     let defaultSelectType: SelectType | undefined;
-
-    // 初始，scale 填入默认值
-    if (!value) {
-      defaultSelectType = selectOptions[0].value;
-      // 非自定义数据情况
-    } else if (!value.isCustom) {
-      // 判断 value 类型是否有效
-      const isValid = selectOptions.some((item) => item.value === value.type);
-      if (!isValid) {
+    // 初始类型
+    if (!lastDataStateRef.current) {
+      if (value) {
+        lastDataStateRef.current = { dataType, domain };
+      } else {
         defaultSelectType = selectOptions[0].value;
+
+        setSelectedType(defaultSelectType);
+        //@ts-ignore
+        onChange?.({ isCustom: false, type: defaultSelectType });
+
+        lastDataStateRef.current = { dataType, domain };
       }
+      return;
     }
 
-    // 设置默认选中类型；因类型推断问题，当前传入类型去除 custom
-    if (defaultSelectType && defaultSelectType !== 'custom') {
+    // 对比类型判断 出现类型变更
+    if (lastDataStateRef.current.dataType !== dataType) {
+      defaultSelectType = selectOptions[0].value;
+
       setSelectedType(defaultSelectType);
+      //@ts-ignore
       onChange?.({ isCustom: false, type: defaultSelectType });
-    }
-  }, [selectOptions]);
 
-  // 自定义 scale 且数据 domain 发生更新时，自动计算默认值
-  useUpdateEffect(() => {
-    if (selectedType === 'custom' && value?.domain && value.domain.length !== 0) {
-      const range = value.range && value.range.length ? [...new Set(value.range)] : defaultColors;
-      const _defaultValue = getDefaultValue(dataType, domain, range);
-      if (onChange)
-        onChange({
-          ..._defaultValue,
-        });
+      lastDataStateRef.current = { dataType, domain };
+      return;
     }
-  }, [domain.toString()]);
+
+    // 类型没有发生变更，但是 domain 出现变更，需要进行重新赋予默认值
+    if (lastDataStateRef.current.domain.toString() !== domain.toString()) {
+      if (value && value?.domain && value.domain.length !== 0) {
+        const range = value.range && value.range.length ? [...new Set(value.range)] : defaultColors;
+        const _defaultValue = getDefaultValue(dataType, domain, range);
+        if (onChange)
+          onChange({
+            ..._defaultValue,
+          });
+      }
+      lastDataStateRef.current = { dataType, domain };
+      return;
+    }
+  }, [dataType, domain.toString()]);
 
   return wrapSSR(
     <Select

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/index.tsx
@@ -4,7 +4,7 @@ import { useUpdateEffect } from 'ahooks';
 import { Divider, Select } from 'antd';
 import cls from 'classnames';
 import React, { useEffect, useMemo, useState } from 'react';
-import { DEHAULT_OPTIONS } from './constants';
+import { DEHAULT_OPTIONS, DEHAULT_COLORS } from './constants';
 import CustomMappingColor from './CustomMappingColors';
 import { getCustomMappingData, getDefaultValue, getScaleByCustomMappingData } from './helper';
 import useStyle from './style';
@@ -35,9 +35,16 @@ type ScaleSelectorProp = {
 
 const Internal = (props: ScaleSelectorProp) => {
   const prefixCls = usePrefixCls('formily-scale-selector');
-  // TODO: dataType string 或 number 设置不同的  defaultColors
-  const { dataType, value, domain = [], defaultColors = ['#f00', '#ff0', '#00f', '#faa'], onChange } = props;
+  const { dataType, value, domain = [], onChange } = props;
   const [wrapSSR, hashId] = useStyle(prefixCls);
+
+  const defaultColors = useMemo(() => {
+    if (props.defaultColors) {
+      return props.defaultColors;
+    }
+
+    return DEHAULT_COLORS[dataType];
+  }, [dataType]);
 
   const customMappingData = useMemo(() => {
     if (value) {
@@ -101,8 +108,7 @@ const Internal = (props: ScaleSelectorProp) => {
   // 自定义 scale 且数据 domain 发生更新时，自动计算默认值
   useUpdateEffect(() => {
     if (selectedType === 'custom' && value?.domain && value.domain.length !== 0) {
-      // TODO value.range 空数组情况
-      const range = value.range ? [...new Set(value.range)] : defaultColors;
+      const range = value.range && value.range.length ? [...new Set(value.range)] : defaultColors;
       const _defaultValue = getDefaultValue(dataType, domain, range);
       if (onChange)
         onChange({

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/index.tsx
@@ -1,7 +1,7 @@
 import { usePrefixCls } from '@formily/antd-v5/esm/__builtins__';
 import { connect } from '@formily/react';
 import { useUpdateEffect } from 'ahooks';
-import { Select, Divider } from 'antd';
+import { Divider, Select } from 'antd';
 import cls from 'classnames';
 import React, { useEffect, useMemo, useState } from 'react';
 import { DEHAULT_OPTIONS } from './constants';
@@ -35,6 +35,7 @@ type ScaleSelectorProp = {
 
 const Internal = (props: ScaleSelectorProp) => {
   const prefixCls = usePrefixCls('formily-scale-selector');
+  // TODO: dataType string 或 number 设置不同的  defaultColors
   const { dataType, value, domain = [], defaultColors = ['#f00', '#ff0', '#00f', '#faa'], onChange } = props;
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
@@ -100,6 +101,7 @@ const Internal = (props: ScaleSelectorProp) => {
   // 自定义 scale 且数据 domain 发生更新时，自动计算默认值
   useUpdateEffect(() => {
     if (selectedType === 'custom' && value?.domain && value.domain.length !== 0) {
+      // TODO value.range 空数组情况
       const range = value.range ? [...new Set(value.range)] : defaultColors;
       const _defaultValue = getDefaultValue(dataType, domain, range);
       if (onChange)

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/index.tsx
@@ -35,7 +35,7 @@ type ScaleSelectorProp = {
 const Internal = (props: ScaleSelectorProp) => {
   const prefixCls = usePrefixCls('formily-scale-selector');
   const { dataType, value, domain = [], onChange } = props;
-  const lastDataStateRef = useRef<{ dataType: 'string' | 'number'; domain: [number, number] | string[] } | null>(null);
+  const lastDataStateRef = useRef<Pick<ScaleSelectorProp, 'dataType' | 'domain'> | null>(null);
   const [wrapSSR, hashId] = useStyle(prefixCls);
 
   const defaultColors = useMemo(() => {
@@ -84,7 +84,7 @@ const Internal = (props: ScaleSelectorProp) => {
 
   useEffect(() => {
     let defaultSelectType: SelectType | undefined;
-    // 初始类型
+    // 初始化没有值时，设置第一项为默认值
     if (!lastDataStateRef.current) {
       if (value) {
         lastDataStateRef.current = { dataType, domain };

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/index.tsx
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/index.tsx
@@ -140,6 +140,7 @@ const Internal = (props: ScaleSelectorProp) => {
                   dataType={dataType}
                   domain={domain}
                   value={customMappingData}
+                  unknown={value?.unknown}
                   onChange={(ranges: CustomMappingData) => onValueChange(ranges)}
                 />
               </>

--- a/packages/li-p2/src/LayerAttribute/components/ScaleSelector/type.ts
+++ b/packages/li-p2/src/LayerAttribute/components/ScaleSelector/type.ts
@@ -7,6 +7,7 @@ export type CustomMappingColorItem = {
 export type CustomMappingData = {
   type: 'number' | 'string' | 'custom';
   list: CustomMappingColorItem[];
+  unknown?: string;
 };
 
 export type SelectType = 'custom' | 'quantize' | 'quantile' | 'cat';
@@ -18,4 +19,5 @@ export type SelectorValue = {
   isCustom: boolean;
   domain?: string[] | number[];
   range?: string[];
+  unknown?: string;
 };

--- a/packages/li-sdk/package.json
+++ b/packages/li-sdk/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@ant-design/icons": "^5.0.1",
     "@antv/l7": "^2.17.2",
-    "@antv/larkmap": "^1.4.1",
+    "@antv/larkmap": "^1.4.9",
     "@formily/json-schema": "^2.2.4",
     "@types/lodash-es": "^4.17.6",
     "@types/react": "^18.0.0",
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "@antv/l7": "^2.17.2",
-    "@antv/larkmap": "^1.4.1",
+    "@antv/larkmap": "^1.4.9",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },


### PR DESCRIPTION
1、数值类型数据添加逻辑修改完善
2、文本类型补充未定义颜色展示效果
3、图标图层图例展示

![image](https://github.com/antvis/L7VP/assets/81275881/902589f8-0a79-4777-977a-ce913f16ed3f)
![image](https://github.com/antvis/L7VP/assets/81275881/3a1fce8d-8904-4750-ab3d-80ecdcc5ab6b)

